### PR TITLE
fix: properly check string length

### DIFF
--- a/lua/langmapper/config.lua
+++ b/lua/langmapper/config.lua
@@ -69,11 +69,11 @@ local function check_deprecated(opts)
 end
 
 local function check_layouts()
-  local def_len = vim.fn.strdisplaywidth(M.config.default_layout)
+  local def_len = vim.fn.strchars(M.config.default_layout)
   for _, lang in ipairs(vim.tbl_keys(M.config.layouts)) do
     local layout = M.config.layouts[lang]
     local len = layout.default_layout and vim.fn.strdisplaywidth(layout.default_layout) or def_len
-    local l_len = vim.fn.strdisplaywidth(layout.layout)
+    local l_len = vim.fn.strchars(layout.layout)
     if len ~= l_len then
       local msg =
         'Langmapper: "default_layout" and "layout" contain different number of characters. Check your config for "%s".'

--- a/lua/langmapper/config.lua
+++ b/lua/langmapper/config.lua
@@ -72,7 +72,7 @@ local function check_layouts()
   local def_len = vim.fn.strchars(M.config.default_layout)
   for _, lang in ipairs(vim.tbl_keys(M.config.layouts)) do
     local layout = M.config.layouts[lang]
-    local len = layout.default_layout and vim.fn.strdisplaywidth(layout.default_layout) or def_len
+    local len = layout.default_layout and vim.fn.strchars(layout.default_layout) or def_len
     local l_len = vim.fn.strchars(layout.layout)
     if len ~= l_len then
       local msg =


### PR DESCRIPTION
Hi, thanks for this wonderful plugin! To check the length of a string, you should use the function `vim.fn.strchars` instead of the function `vim.fn. strdisplaywidth`, since the function `vim.fn.strdisplaywidth` returns not the size of the string, but its width on the screen. For example, due to the use of `vim.fn.strdisplaywidth`, I get an error

```
Langmapper: "default_layout" and "layout" contain different number of characters. Check your config for "ru".
```

Еще раз спасибо за плагин, приятно видеть русскоговорящих в сообществе Neovim :)