### PR TITLE
fix(get_keymap): case insensitive compare

### DIFF
--- a/lua/langmapper/init.lua
+++ b/lua/langmapper/init.lua
@@ -175,7 +175,7 @@ local function filter_default_keymaps(mappings)
 
   for _, mapping in ipairs(mappings) do
     local lhs = mapping.lhs
-    if lhs == get_default_translation(lhs) then
+    if lhs:lower() == get_default_translation(lhs):lower() then
       table.insert(filtered, mapping)
     end
   end


### PR DESCRIPTION
Without this fix when using the command line (via `q:`) an error occurs when `nvim-cmp` is enabled:
```
Error executing vim.schedule lua callback: ....local/share/nvim/lazy/nvim-cmp/lua/cmp/utils/keymap.lua:29: E11: Invalid in command-line window;
<CR> executes, CTRL-C quits
stack traceback:
        [C]: in function 'nvim_buf_delete'
        ....local/share/nvim/lazy/nvim-cmp/lua/cmp/utils/keymap.lua:29: in function 'normalize'
        ...valov/.local/share/nvim/lazy/nvim-cmp/lua/cmp/config.lua:175: in function 'normalize'
        ...valov/.local/share/nvim/lazy/nvim-cmp/lua/cmp/config.lua:126: in function 'callback'
        .../.local/share/nvim/lazy/nvim-cmp/lua/cmp/utils/cache.lua:38: in function 'get'
        ...valov/.local/share/nvim/lazy/nvim-cmp/lua/cmp/config.lua:134: in function 'enabled'
        ...shvalov/.local/share/nvim/lazy/nvim-cmp/lua/cmp/init.lua:300: in function 'callback'
        .../.local/share/nvim/lazy/nvim-cmp/lua/cmp/utils/async.lua:165: in function <.../.local/share/nvim/lazy/nvim-cmp/lua/cmp/utils/async.lu
a:163>
```

As I understand it, the fact is that some mappings are set in uppercase (for example, `C-Z` instead of `C-z`). Therefore, the following condition is not met (see [code](https://github.com/Wansmer/langmapper.nvim/blob/30603d6f428f1944c3d85bd8dd6456bccdb39207/lua/langmapper/init.lua#L178-L180)):

```lua
if lhs == get_default_translation(lhs) then
  table.insert(filtered, mapping)
end
```

This patch makes the check case-insensitive.